### PR TITLE
Add Grunt task to copy code highlighting CSS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,10 +22,19 @@ module.exports = function (grunt) {
                 }
             }
         },
+        copy: {
+            main: {
+                files: [{
+                    expand: false,
+                    src: 'node_modules/highlight.js/styles/github.css',
+                    dest: 'css/github.css'
+                }]
+            }
+        },
         watch: {
             css: {
                 files: 'sass/**/*.scss',
-                tasks: ['sass', 'cssmin']
+                tasks: ['sass', 'cssmin', 'copy']
             }
         }
     });
@@ -33,8 +42,9 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-sass');
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-contrib-cssmin');
+    grunt.loadNpmTasks('grunt-contrib-copy');
 
     // Default task(s).
-    grunt.registerTask('default', ['sass', 'cssmin', 'watch']);
+    grunt.registerTask('default', ['sass', 'cssmin', 'copy', 'watch']);
 
 };

--- a/css/github.css
+++ b/css/github.css
@@ -1,0 +1,99 @@
+/*
+
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+
+*/
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #333;
+  background: #f8f8f8;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #998;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-subst {
+  color: #333;
+  font-weight: bold;
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag .hljs-attr {
+  color: #008080;
+}
+
+.hljs-string,
+.hljs-doctag {
+  color: #d14;
+}
+
+.hljs-title,
+.hljs-section,
+.hljs-selector-id {
+  color: #900;
+  font-weight: bold;
+}
+
+.hljs-subst {
+  font-weight: normal;
+}
+
+.hljs-type,
+.hljs-class .hljs-title {
+  color: #458;
+  font-weight: bold;
+}
+
+.hljs-tag,
+.hljs-name,
+.hljs-attribute {
+  color: #000080;
+  font-weight: normal;
+}
+
+.hljs-regexp,
+.hljs-link {
+  color: #009926;
+}
+
+.hljs-symbol,
+.hljs-bullet {
+  color: #990073;
+}
+
+.hljs-built_in,
+.hljs-builtin-name {
+  color: #0086b3;
+}
+
+.hljs-meta {
+  color: #999;
+  font-weight: bold;
+}
+
+.hljs-deletion {
+  background: #fdd;
+}
+
+.hljs-addition {
+  background: #dfd;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}

--- a/engagement.html
+++ b/engagement.html
@@ -19,7 +19,7 @@
 	<link rel="stylesheet" href="css/toolkit.css">
 
 	<!-- Syntax highlighting styles and JavaScript-->
-	<link rel="stylesheet" href="node_modules/highlight.js/styles/github.css">
+	<link rel="stylesheet" href="css/github.css">
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/highlight.min.js"></script>
 	<script>hljs.initHighlightingOnLoad();</script>
 

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 	<link rel="stylesheet" href="css/toolkit.css">
 
 	<!-- Syntax highlighting styles and JavaScript-->
-	<link rel="stylesheet" href="node_modules/highlight.js/styles/github.css">
+	<link rel="stylesheet" href="css/github.css">
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/highlight.min.js"></script>
 	<script>hljs.initHighlightingOnLoad();</script>
 
@@ -59,9 +59,11 @@
 		<div class="row">
 			<div class="col-md-10" id="content">
 				<section id="intro">
+
 					<h1><strong>NAVI</strong> <br>The National Archives <br>Visual Identity</h1>
-					
+
 					<p>This frontend toolkit is a collection of CSS and HTML elements for using as part of your application's frontend. A way of creating flexible and unique layouts whilst also maintaining consistency across TNA online.</p>
+
 					<p>Designers and developers can use the toolkit to:</p>
 					<ul>
 						<li>create applications with a consistent look and feel</li>
@@ -94,7 +96,7 @@
                 -->
 				<section id="grid">
 					<h2>Grid and layout</h2>
-					
+
 					<h3>Default page layout</h3>
 					<h5>Examples</h5>
 					<div class="examples tna-page">
@@ -233,7 +235,7 @@
                 -->
 				<section id="typography">
 					<h2>Typography</h2>
-					
+
 					<h3>Headings</h3>
 					<h5>Examples</h5>
 					<div class="examples">
@@ -463,7 +465,7 @@
                 -->
 				<section id="buttons">
 					<h2>Buttons</h2>
-					
+
 					<h3>Link buttons</h3>
 					<h5>Examples</h5>
 					<div class="examples">
@@ -495,7 +497,7 @@
                 -->
 				<section id="colours">
 					<h2>Colours</h2>
-					
+
 					<h3>Contextual backgrounds</h3>
 					<h5>Examples</h5>
 					<div class="examples">
@@ -526,7 +528,7 @@
                 -->
 				<section id="forms">
 					<h2>Forms</h2>
-					
+
 					<h3>Basic form</h3>
 					<h5>Examples</h5>
 					<div class="examples">
@@ -577,7 +579,7 @@
                 -->
 				<section id="tables">
 					<h2>Tables</h2>
-					
+
 					<h3>Default table</h3>
 					<h5>Examples</h5>
 					<div class="examples">
@@ -628,7 +630,7 @@
                 -->
 				<section id="icons">
 					<h2>Icons</h2>
-					
+
 					<h3>Icons</h3>
 					<h5>Examples</h5>
 					<div class="examples">
@@ -666,7 +668,7 @@
 
 			</div>
 			<div class="col-md-12" id="section-footer">
-				
+
 			</div>
 		</div>
 	</div>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "grunt": "^1.0.4",
+    "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-cssmin": "^3.0.0",
     "grunt-contrib-sass": "^0.9.2",
     "grunt-contrib-watch": "^1.1.0"


### PR DESCRIPTION
I've noticed that the syntax highlighting CSS is not visible on the
CDN. This seems to be because the files are being referenced from
node_modules.

I've therefore introduced a Grunt task which copies the relevant file
from node_modules to the /css directory